### PR TITLE
Made Pectinid Plotly friendly

### DIFF
--- a/Maps/combo_shp.R
+++ b/Maps/combo_shp.R
@@ -6,7 +6,7 @@
 #1:   loc         The folder in which all the different shapefile layers are found.
 #2:   make.sf     Do you want the object returned to be an SF or an sp object.  Defaults to = F to maintain backwards compatability with older code.
 #3:   make.polys  Do you want the object to be returned as a polygon.  This is handy if you have a shapefile that is lines but you want polygons returned
-all.layers <- function(loc,make.sf = F,make.polys=F)
+combo.shp <- function(loc,make.sf = F,make.polys=F,make.lines =F)
 {
   require(sf)  || stop("You need to have the package 'sf' or this won't work pal")
   require(rgdal)  || stop("You need to have the package 'sf' or this won't work pal")
@@ -31,18 +31,35 @@ all.layers <- function(loc,make.sf = F,make.polys=F)
       #my.shp[[i]] <- concaveman(my.shp[[i]])
       my.shp[[i]] <- st_cast(my.shp[[i]],"MULTIPOLYGON")
     }
+    
+    if(make.lines == T) 
+    {
+      #my.shp[[i]] <- concaveman(my.shp[[i]])
+      my.shp[[i]] <- st_cast(my.shp[[i]],"MULTILINESTRING")
+    }
+    
     # Need to put a name on it now
     if(nrow(my.shp[[i]]) == 1) my.shp[[i]]$ID <- lyr[i]
     if(nrow(my.shp[[i]])  >1) my.shp[[i]]$ID <- paste0(lyr[i],"_",my.shp[[i]]$ID)
     
   } # end for (i in 1:length(lyr)) 
   
+  # So this checks if the number of columns in the data is all the same, if so
+  # they are easy to merge...
   num.cols <- unique(purrr::map_chr(my.shp, function(x) ncol(x)))
+  # The number of colums is not the same we need to clean up the data so we can merge them into one object
+  # We should also spit a warning here...
   if(length(num.cols) > 1){
+    cat("Warning, you are combining shapefiles with different numbers of columns, this method retains only the first column which we rename 'ID'
+       so you might want to try a different tool to combine your data as this method will lead to lose of some data!!!")
     for (i in 1:length(lyr)) 
     {
+      # Just keep the first column
+      my.shp[[i]] <- my.shp[[i]][,1]
+      # And rename that column to ID
+      names(my.shp[[i]]) <- c("ID","geometry")
       if(i==1) full.shp <- my.shp[[i]]
-      if(i>1) full.shp <- st_union(full.shp, st_transform(my.shp[[i]], st_crs(full.shp)))
+      if(i>1) full.shp <- rbind(full.shp,st_transform(my.shp[[i]],st_crs(full.shp)))
     }
   }
   if(length(num.cols) == 1){
@@ -53,6 +70,7 @@ all.layers <- function(loc,make.sf = F,make.polys=F)
       full.shp <- rbind(full.shp, st_transform(my.shp[[i]], st_crs(crs.1)))
     }
   }
+  
   # Convert to an SP object as required.
   if(make.sf ==F) full.shp <- as_Spatial(full.shp)
   # Give each layer a proper name and return the results for later.

--- a/Maps/convert_coords.R
+++ b/Maps/convert_coords.R
@@ -25,7 +25,7 @@ convert.coords <- function(plot.extent= list(y = c(40,46),x = c(-68,-55)),in.csy
   {
     #offshore
     # This includes southern Newfoundland, this is a nice map of everywhere 
-    if(plot.extent %in% c('NL','nl',"Newfoundland","NEWFOUNDLAND","newfoundland"))                 {y=c(40.00,48.00);x=c(-68.00,-54.00)} 
+    if(plot.extent %in% c('NL','nl',"Newfoundland","NEWFOUNDLAND","newfoundland",'nf',"NF","NFLD")){y=c(40.00,48.00);x=c(-68.00,-54.00)} 
     # This is the Martime offshore, includes most of the inshore too just due to nature of area
     if(plot.extent%in% c('offshore',"OFFSHORE","Offshore"))                                        {y=c(40.00,46.00);x=c(-68.00,-55.00)}
     if(plot.extent%in% c('SS','ss','Scotian Shelf','scotian shelf',"SCOTIAN SHELF"))		           {y=c(40.50,47.00);x=c(-68.00,-57.00)}


### PR DESCRIPTION
This is the main plotly implementation revision to pectinid.  Still having various minor issues with colors, but everything appears to be fully functional now.  The only thing that changes is there is a plot_as input, it defaults to 'ggplot' so old code should work as always without specfying anything.  

Also changes to `**combine_shapefile_layers**` know known as `**combo_shp** ` the function call is now combo.shp.  I also added option to force the output to be a "MULTILINESTRING".  Super minor change to **`conver_coords`** which allows a couple more options for names when trying to plot all the way to NFLD.  Note that at the time of this revision there was a bug in marmap which was causing issues so the bathy extent was hard coded, something we'll want to change back when bug is fixed.